### PR TITLE
feat(upgrade2springboot3):Update Maven properties and dependencies ac…

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
-          files: ./*/target/site/jacoco/jacoco.xml
+          files: ./mundo-core/target/site/jacoco/jacoco.xml,./mundo-xml/target/site/jacoco/jacoco.xml,./mundo-process/target/site/jacoco/jacoco.xml,./spring-boot-starter-mundo/target/site/jacoco/jacoco.xml,./target/site/jacoco-aggregate/jacoco.xml

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
           files: ./mundo-core/target/site/jacoco/jacoco.xml,./mundo-xml/target/site/jacoco/jacoco.xml,./mundo-process/target/site/jacoco/jacoco.xml,./spring-boot-starter-mundo/target/site/jacoco/jacoco.xml,./target/site/jacoco-aggregate/jacoco.xml

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -8,18 +8,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
       - name: Build with Maven
         run: |
           mvn --batch-mode --update-snapshots verify
-          mvn cobertura:cobertura -Dcobertura.report.format=xml
-      - name : Upload coverage to Codecov
+      - name: Generate coverage report
+        run: mvn jacoco:report
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
-          files: ./target/site/cobertura/coverage.xml
+          files: ./*/target/site/jacoco/jacoco.xml

--- a/mundo-core/pom.xml
+++ b/mundo-core/pom.xml
@@ -15,8 +15,8 @@
     <url>http://www.bluslee.com</url>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/mundo-process/pom.xml
+++ b/mundo-process/pom.xml
@@ -22,8 +22,8 @@
     </build>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/mundo-xml/pom.xml
+++ b/mundo-xml/pom.xml
@@ -14,6 +14,11 @@
     <name>mundo-xml</name>
     <url>http://www.bluslee.com</url>
 
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -32,8 +37,23 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -314,30 +314,49 @@
                     </dependencies>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
-                    <configuration>
-                        <check>
-                            <branchRate>70</branchRate>
-                            <lineRate>70</lineRate>
-                            <haltOnFailure>true</haltOnFailure>
-                            <totalBranchRate>70</totalBranchRate>
-                            <totalLineRate>70</totalLineRate>
-                            <packageLineRate>70</packageLineRate>
-                            <packageBranchRate>70</packageBranchRate>
-                        </check>
-                        <aggregate>true</aggregate>
-                        <encoding>${project.build.sourceEncoding}</encoding>
-                        <quiet>true</quiet>
-                        <formats>
-                            <format>html</format>
-                            <format>xml</format>
-                        </formats>
-                        <instrumentation>
-                            <ignoreTrivial>true</ignoreTrivial>
-                        </instrumentation>
-                    </configuration>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.8</version>
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>check</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <rule>
+                                        <element>BUNDLE</element>
+                                        <limits>
+                                            <limit>
+                                                <counter>LINE</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.70</minimum>
+                                            </limit>
+                                            <limit>
+                                                <counter>BRANCH</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.70</minimum>
+                                            </limit>
+                                        </limits>
+                                    </rule>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -380,8 +399,8 @@
                         <artifactId>maven-site-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>cobertura-maven-plugin</artifactId>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -430,8 +449,8 @@
                         <artifactId>maven-site-plugin</artifactId>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>cobertura-maven-plugin</artifactId>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,13 @@
                             </goals>
                         </execution>
                         <execution>
+                            <id>report-aggregate</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>report-aggregate</goal>
+                            </goals>
+                        </execution>
+                        <execution>
                             <id>check</id>
                             <goals>
                                 <goal>check</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <xstream.version>1.4.19</xstream.version>
         <guava.version>32.0.0-jre</guava.version>
         <mundo.version>0.0.1</mundo.version>
@@ -57,8 +57,8 @@
         <dom4j.version>2.1.3</dom4j.version>
         <jaxen.version>1.2.0</jaxen.version>
         <reflections.version>0.10.2</reflections.version>
-        <spring.boot.starter.version>2.6.0</spring.boot.starter.version>
-        <snakeyaml.version>1.32</snakeyaml.version>
+        <spring.boot.starter.version>3.2.0</spring.boot.starter.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
     </properties>
 
     <dependencyManagement>
@@ -166,6 +166,13 @@
 
             <dependency>
                 <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-configuration-processor</artifactId>
+                <version>${spring.boot.starter.version}</version>
+                <optional>true</optional>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-test</artifactId>
                 <version>${spring.boot.starter.version}</version>
                 <scope>test</scope>
@@ -194,11 +201,11 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.10.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.21.0</version>
+                    <version>2.22.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>

--- a/spring-boot-starter-mundo/pom.xml
+++ b/spring-boot-starter-mundo/pom.xml
@@ -14,8 +14,8 @@
     <artifactId>spring-boot-starter-mundo</artifactId>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -23,6 +23,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -36,8 +42,31 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.4.7</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/spring-boot-starter-mundo/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-starter-mundo/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.bluslee.mundo.springboot.starter.MundoAutoConfiguration 

--- a/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoAutoConfigurationEmptyTest.java
+++ b/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoAutoConfigurationEmptyTest.java
@@ -1,24 +1,24 @@
 package com.bluslee.mundo.springboot.starter.test;
 
-import com.bluslee.mundo.core.process.base.BaseProcessNode;
 import com.bluslee.mundo.core.process.base.Repository;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
- * 读取没有配置mundo的配置文件单元测试.
+ * 读取配置没有配置mundo的配置文件单元测试.
  * @author carl.che
  */
 @ActiveProfiles(value = "empty")
 public class MundoAutoConfigurationEmptyTest extends MundoStarterTest {
 
     @Autowired(required = false)
-    private Repository<? extends BaseProcessNode> repository;
+    private Repository repository;
 
     @Test
-    public void test() {
-        Assert.assertNull(repository);
+    public void mundoFactoryTest() {
+        Assertions.assertNull(repository);
     }
+
 }

--- a/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoAutoConfigurationEnabledFalseTest.java
+++ b/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoAutoConfigurationEnabledFalseTest.java
@@ -1,24 +1,24 @@
 package com.bluslee.mundo.springboot.starter.test;
 
-import com.bluslee.mundo.core.process.base.BaseProcessNode;
 import com.bluslee.mundo.core.process.base.Repository;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
- * 读取mundo.enabled == false的配置文件单元测试.
+ * 读取配置mundo.enabled == false的配置文件单元测试.
  * @author carl.che
  */
 @ActiveProfiles(value = "enabled-false")
 public class MundoAutoConfigurationEnabledFalseTest extends MundoStarterTest {
 
     @Autowired(required = false)
-    private Repository<? extends BaseProcessNode> repository;
+    private Repository repository;
 
     @Test
-    public void test() {
-        Assert.assertNull(repository);
+    public void mundoFactoryTest() {
+        Assertions.assertNull(repository);
     }
+
 }

--- a/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoAutoConfigurationEnabledTrueTest.java
+++ b/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoAutoConfigurationEnabledTrueTest.java
@@ -6,8 +6,8 @@ import com.bluslee.mundo.core.process.base.Repository;
 import com.bluslee.mundo.springboot.starter.MundoAutoConfiguration;
 import com.bluslee.mundo.springboot.starter.MundoProperties;
 import com.bluslee.mundo.xml.XmlSchema;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import java.util.Arrays;
@@ -32,12 +32,12 @@ public class MundoAutoConfigurationEnabledTrueTest extends MundoStarterTest {
 
     @Test
     public void autowiredTest() {
-        Assert.assertNotNull(repository);
+        Assertions.assertNotNull(repository);
         List<XmlSchema.ProcessSchema> dom4jProcessSchemas = xmlProcessor.getProcessSchemas();
         Map<List<String>, List<XmlSchema.ProcessSchema>> expectDistinctProcessSchemas = dom4jProcessSchemas
                 .stream()
                 .collect(Collectors.groupingBy(processSchema -> Arrays.asList(processSchema.getId(), processSchema.getVersion().toString())));
-        Assert.assertEquals(expectDistinctProcessSchemas.size(), repository.processes().size());
+        Assertions.assertEquals(expectDistinctProcessSchemas.size(), repository.processes().size());
     }
 
     @Test
@@ -48,14 +48,13 @@ public class MundoAutoConfigurationEnabledTrueTest extends MundoStarterTest {
         Map<List<String>, List<XmlSchema.ProcessSchema>> expectDistinctProcessSchemas = dom4jProcessSchemas
                 .stream()
                 .collect(Collectors.groupingBy(processSchema -> Arrays.asList(processSchema.getId(), processSchema.getVersion().toString())));
-        Assert.assertEquals(expectDistinctProcessSchemas.size(), repository.processes().size());
+        Assertions.assertEquals(expectDistinctProcessSchemas.size(), repository.processes().size());
     }
 
     @Test
     public void createBeanNoXmlConfigTest() {
         MundoAutoConfiguration mundoAutoConfiguration = new MundoAutoConfiguration();
         MundoProperties noXmlConfig = new MundoProperties();
-        Assert.assertThrows(MundoException.class, () -> mundoAutoConfiguration.createRepository(noXmlConfig));
+        Assertions.assertThrows(MundoException.class, () -> mundoAutoConfiguration.createRepository(noXmlConfig));
     }
-
 }

--- a/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoPropertiesEmptyTest.java
+++ b/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoPropertiesEmptyTest.java
@@ -1,8 +1,8 @@
 package com.bluslee.mundo.springboot.starter.test;
 
 import com.bluslee.mundo.springboot.starter.MundoProperties;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -18,7 +18,7 @@ public class MundoPropertiesEmptyTest extends MundoStarterTest {
 
     @Test
     public void parsePropertiesTest() {
-        Assert.assertNull(actualProperties);
+        Assertions.assertNull(actualProperties);
     }
 
 }

--- a/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoPropertiesEnabledFalseTest.java
+++ b/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoPropertiesEnabledFalseTest.java
@@ -1,8 +1,8 @@
 package com.bluslee.mundo.springboot.starter.test;
 
 import com.bluslee.mundo.springboot.starter.MundoProperties;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -18,7 +18,7 @@ public class MundoPropertiesEnabledFalseTest extends MundoStarterTest {
 
     @Test
     public void parsePropertiesTest() {
-        Assert.assertNull(actualProperties);
+        Assertions.assertNull(actualProperties);
     }
 
 }

--- a/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoPropertiesEnabledTrueTest.java
+++ b/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoPropertiesEnabledTrueTest.java
@@ -3,8 +3,8 @@ package com.bluslee.mundo.springboot.starter.test;
 import com.bluslee.mundo.core.exception.MundoException;
 import com.bluslee.mundo.springboot.starter.MundoProperties;
 import com.google.common.base.CaseFormat;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.yaml.snakeyaml.Yaml;
@@ -27,7 +27,7 @@ public class MundoPropertiesEnabledTrueTest extends MundoStarterTest {
     @Test
     public void parsePropertiesTest() {
         //mundo.enabled == true, MundoProperties不能为空
-        Assert.assertNotNull(actualProperties);
+        Assertions.assertNotNull(actualProperties);
         //使用Yaml直接读取配置文件比较配置文件与注入的属性是否一致
         Yaml yaml = new Yaml();
         InputStream resourceAsStream = getClass().getResourceAsStream("/application-enabled-true.yml");
@@ -35,7 +35,7 @@ public class MundoPropertiesEnabledTrueTest extends MundoStarterTest {
         Optional<Map> mundoMapOpt = Optional.ofNullable(yamlMap)
                 .flatMap(map -> Optional.ofNullable(map.get("mundo")))
                 .flatMap(mundoObj -> Optional.ofNullable((Map) mundoObj));
-        Assert.assertTrue(mundoMapOpt.isPresent());
+        Assertions.assertTrue(mundoMapOpt.isPresent());
         propertyEquals(mundoMapOpt.get(), actualProperties);
     }
 
@@ -56,7 +56,7 @@ public class MundoPropertiesEnabledTrueTest extends MundoStarterTest {
             } catch (NoSuchMethodException e) {
                 throw new MundoException("get method error", e);
             }
-            Assert.assertNotNull(declaredMethod);
+            Assertions.assertNotNull(declaredMethod);
             Object invokeRes = null;
             try {
                 invokeRes = declaredMethod.invoke(instance, null);
@@ -66,7 +66,7 @@ public class MundoPropertiesEnabledTrueTest extends MundoStarterTest {
             if (val instanceof Map) {
                 propertyEquals((Map) val, invokeRes);
             } else {
-                Assert.assertEquals(val, invokeRes);
+                Assertions.assertEquals(val, invokeRes);
             }
         });
     }

--- a/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoStarterTest.java
+++ b/spring-boot-starter-mundo/src/test/java/com/bluslee/mundo/springboot/starter/test/MundoStarterTest.java
@@ -1,16 +1,13 @@
 package com.bluslee.mundo.springboot.starter.test;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * MundoStarterTest.
  * @author carl.che
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = MundoStarterTest.class)
 @SpringBootApplication
 public class MundoStarterTest {

--- a/spring-boot-starter-mundo/src/test/resources/application.yml
+++ b/spring-boot-starter-mundo/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  main:
+    banner-mode: off 


### PR DESCRIPTION
- Upgraded Java compiler version from 1.8 to 17 in pom.xml files for all modules.
- Updated Spring Boot starter version from 2.6.0 to 3.2.0 in relevant modules.
- Added Spring Boot configuration processor dependency in spring-boot-starter-mundo and mundo-core.
- Replaced JUnit 4 with JUnit 5 (junit-jupiter) in test classes for improved testing capabilities.
- Updated various dependencies to their latest versions for better performance and security.